### PR TITLE
Use generic HTTP config endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # DNS config for NSQD
 
-Dynamically configure nsqd with IP addresses from DNS record.
+Dynamically configure `nsqd` or `nsqadmin` with IP addresses from DNS A-record.
 
 ### Command Line Options
 
 ```
 -lookupd-dns-address=: <addr> of DNS A record that provides nsqlookupd IP Addresses
--lookupd-tcp-port=4160: <port> of nsqlookupd for TCP connection
--nsqd-http-address="0.0.0.0:4151": <addr>:<port> of the nsqd to configure
+-lookupd-tcp-port=4160: <port> of nsqlookupd TCP address
+-config-http-address=: <addr>:<port> of the HTTP config endpoint
 ```
 
 ### Run
@@ -15,7 +15,7 @@ Dynamically configure nsqd with IP addresses from DNS record.
 ```
 docker run --rm -it harlow/nsqd-discovery \
   --lookupd-dns-address $LOOKUPD_DNS_ADDRESS \
-  --nsqd-http-address $NSQD_HTTP_ADDRESS:4151
+  --config-http-address $CONFIG_HTTP_ADDRESS
 ```
 
 ### Tiny Docker Image

--- a/dnscfg/dnscfg.go
+++ b/dnscfg/dnscfg.go
@@ -1,0 +1,24 @@
+package dnscfg
+
+import(
+  "net"
+  "fmt"
+)
+
+// Get the IP addresses from DNS records
+// Note: DNS must have A-Record with IP addresses of nsqlookup instances
+func Get(dnsAddr *string, port *int) ([]string, error) {
+  addrs := []string{}
+
+  IPs, err := net.LookupIP(*dnsAddr)
+  if err != nil {
+    return addrs, err
+  }
+
+  for _, IP := range IPs {
+    addr := fmt.Sprintf("%s:%d", IP, *port)
+    addrs = append(addrs, addr)
+  }
+
+  return addrs, nil
+}

--- a/httpcfg/httpcfg.go
+++ b/httpcfg/httpcfg.go
@@ -1,0 +1,51 @@
+package httpcfg
+
+import(
+  "encoding/json"
+  "net/http"
+  "io/ioutil"
+  "bytes"
+  "fmt"
+)
+
+// Get the current lookupd addresses from config endpoint
+func Get(cfgURL string) ([]string, error) {
+  res, err := http.Get(cfgURL)
+  if err != nil {
+    return []string{}, err
+  }
+
+  body, err := ioutil.ReadAll(res.Body)
+  if err != nil {
+    return []string{}, err
+  }
+
+  addrs := []string{}
+  json.Unmarshal(body, &addrs)
+  return addrs, nil
+}
+
+// Set lookupd addresses on config endpoint
+func Set(cfgURL string, addrs []string) error {
+  body, err := json.Marshal(addrs)
+  if err != nil {
+    return err
+  }
+
+  req, err := http.NewRequest("PUT", cfgURL, bytes.NewBuffer(body))
+  if err != nil {
+    return err
+  }
+
+  client := &http.Client{}
+  res, err := client.Do(req)
+  if err != nil {
+    return err
+  }
+
+  if res.StatusCode != 200 {
+    return fmt.Errorf("type=error msg=unable to set config status=%d", res.StatusCode)
+  }
+
+  return nil
+}

--- a/main.go
+++ b/main.go
@@ -1,18 +1,86 @@
 package main
 
 import (
-	"bytes"
-	"encoding/json"
 	"flag"
-	"fmt"
-	"io/ioutil"
 	"log"
-	"net"
-	"net/http"
 	"time"
+
+	"./dnscfg"
+	"./httpcfg"
 )
 
-// test equality between two arrays
+
+
+func main() {
+	var (
+		ldPort 	= flag.Int("lookupd-tcp-port", 4160, "The nsqlookupd tcp port")
+		dnsAddr = flag.String("lookupd-dns-address", "", "The DNS address of nsqlookupd")
+		cfgAddr = flag.String("config-http-address", "", "The IP address of config endpoint")
+	)
+	flag.Parse()
+
+	if *cfgAddr == "" {
+		log.Fatal("arg -lookupd-cfg-address is required")
+	}
+
+	if *dnsAddr == "" {
+		log.Fatal("arg -lookupd-dns-address is required")
+	}
+
+	cfgURL := "http://" + *cfgAddr + "/config/nsqlookupd_tcp_addresses"
+
+	newIPs, err := dnscfg.Get(dnsAddr, ldPort)
+	if err != nil {
+		log.Fatalf("type=error msg=%s err=%s", "dns lookup", err)
+	}
+
+	if len(newIPs) == 0 {
+		log.Printf("type=warn msg=%s addr=%s", "no dns records", *dnsAddr)
+	}
+
+	err = httpcfg.Set(cfgURL, newIPs)
+	if err != nil {
+		log.Printf("type=error msg=%s err=%s", "set config", err)
+	}
+
+	ticker := time.Tick(15 * time.Second)
+	for {
+		select {
+		case <-ticker:
+			newIPs, err = dnscfg.Get(dnsAddr, ldPort)
+			if err != nil {
+				log.Printf("type=error msg=%s err=%s", "dns lookup", err)
+				continue
+			}
+
+			if len(newIPs) == 0 {
+				log.Printf("type=warn msg=%s addr=%s", "no dns records", *dnsAddr)
+				continue
+			}
+
+			oldIPs, err := httpcfg.Get(cfgURL)
+			if err != nil {
+				log.Printf("type=error msg=%s err=%s", "get config", err)
+				continue
+			}
+
+			if eq(newIPs, oldIPs) {
+				log.Printf("type=info msg=%s", "config up to date")
+				continue
+			}
+
+			err = httpcfg.Set(cfgURL, newIPs)
+			if err != nil {
+				log.Printf("type=error msg=%s err=%s", "set config", err)
+				continue
+			}
+
+			log.Printf("type=info msg=%s ips=%s", "set config", newIPs)
+		}
+	}
+}
+
+// test equality of two slices
 func eq(a []string, b []string) bool {
 	if len(a) != len(b) {
 		return false
@@ -25,6 +93,7 @@ func eq(a []string, b []string) bool {
 	return true
 }
 
+// test if slice contains string
 func contains(s []string, e string) bool {
 	for _, a := range s {
 		if a == e {
@@ -32,128 +101,4 @@ func contains(s []string, e string) bool {
 		}
 	}
 	return false
-}
-
-// get the current lookupd IPs from nsqd config
-func getConfgIPs(configAddr string) ([]string, error) {
-	configIPs := []string{}
-
-	res, err := http.Get(configAddr)
-	if err != nil {
-		return configIPs, err
-	}
-
-	body, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		return configIPs, err
-	}
-
-	json.Unmarshal(body, &configIPs)
-	return configIPs, nil
-}
-
-// get lookupd IPs from DNS
-func getLookupdIPs(dnsAddr *string, port *int) ([]string, error) {
-	addrs := []string{}
-
-	IPs, err := net.LookupIP(*dnsAddr)
-	if err != nil {
-		return addrs, err
-	}
-
-	for _, IP := range IPs {
-		addr := fmt.Sprintf("%s:%d", IP, *port)
-		addrs = append(addrs, addr)
-	}
-
-	return addrs, nil
-}
-
-// set lookupd addrs on nsqd
-func setConfig(configAddr string, lookupdAddrs []string) error {
-	body, err := json.Marshal(lookupdAddrs)
-	if err != nil {
-		return err
-	}
-
-	log.Printf("type=info func=setConfig ips=%s", body)
-
-	req, err := http.NewRequest("PUT", configAddr, bytes.NewBuffer(body))
-	if err != nil {
-		return err
-	}
-
-	client := &http.Client{}
-	res, err := client.Do(req)
-	if err != nil {
-		return err
-	}
-
-	if res.StatusCode != 200 {
-		log.Printf("type=error func=setConfig status=%d", res.StatusCode)
-	}
-
-	return nil
-}
-
-func main() {
-	var (
-		lookupdPort = flag.Int("lookupd-tcp-port", 4160, "The nsqlookupd tcp port")
-		dnsAddr     = flag.String("lookupd-dns-address", "", "The DNS address of nsqlookupd")
-		nsqdAddr    = flag.String("nsqd-http-address", "0.0.0.0:4151", "The HTTP address of nsqd")
-	)
-	flag.Parse()
-
-	configAddr := "http://" + *nsqdAddr + "/config/nsqlookupd_tcp_addresses"
-
-	if *dnsAddr == "" {
-		log.Fatal("arg -lookupd-dns-address is required")
-	}
-
-	lookupdIPs, err := getLookupdIPs(dnsAddr, lookupdPort)
-	if err != nil {
-		log.Fatalf("type=error func=getLookupdIPs msg=%s", err)
-	}
-
-	if len(lookupdIPs) == 0 {
-		log.Printf("type=warn msg=%s addr=%s", "no dns records", *dnsAddr)
-	}
-
-	err = setConfig(configAddr, lookupdIPs)
-	if err != nil {
-		log.Printf("type=error func=setConfig msg=%s", err)
-	}
-
-	ticker := time.Tick(15 * time.Second)
-	for {
-		select {
-		case <-ticker:
-			lookupdIPs, err = getLookupdIPs(dnsAddr, lookupdPort)
-			if err != nil {
-				log.Printf("type=error func=getLookupdIPs msg=%s", err)
-			}
-
-			if len(lookupdIPs) == 0 {
-				log.Printf("type=warn msg=%s addr=%s", "no dns records", *dnsAddr)
-				continue
-			}
-
-			configIPs, err := getConfgIPs(configAddr)
-			if err != nil {
-				log.Printf("type=error func=getConfgIPs msg=%s", err)
-				continue
-			}
-
-			if eq(lookupdIPs, configIPs) {
-				log.Printf("type=info func=eq msg=%s", "config up to date")
-				continue
-			}
-
-			err = setConfig(configAddr, lookupdIPs)
-			if err != nil {
-				log.Printf("type=error func=setConfig msg=%s", err)
-				continue
-			}
-		}
-	}
 }


### PR DESCRIPTION
Looking forward we will also need to dynamically configure `nsqadmin` too. 
This change will allow the user to pass in a generic config URL.
- Extract packages for HTTP vs DNS config
- Update logging to include msg and err
