### PR TITLE
Don't fail at startup if no DNS record found

### DIFF
--- a/main.go
+++ b/main.go
@@ -43,12 +43,10 @@ func main() {
 	ips, err := dnscfg.Get(dnsAddr, ldPort)
 	if err != nil {
 		ctx.WithError(err).Error("dns lookup")
-		os.Exit(1)
 	}
 
 	if len(ips) == 0 {
 		ctx.Error("no ip addresses found")
-		os.Exit(1)
 	}
 
 	cfgURL := "http://" + *cfgAddr + "/config/nsqlookupd_tcp_addresses"


### PR DESCRIPTION
discovery were failing fast if DNS record wasn't found at startup.
This causes problem in platforms like Kubernetes which creates
the DNS record after the pod (which includes the discovery)
is started up properly not before hand. So at boot time there is
no DNS record, but right after boot up there is.
Changed it to not fail at startup to the missing DNS, only print
error log about it and continue to normal update loop.

Tested this on Kubernetes and works nicely!
Resolves #3 
