### PR TITLE
add --check-interval

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,7 +19,8 @@ var (
 	dnsAddr     = flag.String("lookupd-dns-address", "", "The nsqlookupd DNS entry")
 	cfgAddr     = flag.String("config-http-address", "", "The config address")
 	httpAddrCfg = flag.Bool("config-addresses-as-http", false, "Config nsqlookupd http addresses")
-)
+        checkInterval = flag.Int("check-interval", 15, "Time interval for checks/update")
+    )
 
 func main() {
 	flag.Parse()
@@ -69,7 +70,7 @@ func main() {
 
 // continue looking at dns entry for changes in config
 func configLoop(ctx log.Interface, cfgURL string) {
-	ticker := time.Tick(15 * time.Second)
+	ticker := time.Tick(time.Duration(*checkInterval) * time.Second)
 
 	for {
 		select {

--- a/main.go
+++ b/main.go
@@ -15,12 +15,12 @@ import (
 )
 
 var (
-	ldPort      = flag.Int("lookupd-tcp-port", 4160, "The nsqlookupd TCP port")
-	dnsAddr     = flag.String("lookupd-dns-address", "", "The nsqlookupd DNS entry")
-	cfgAddr     = flag.String("config-http-address", "", "The config address")
-	httpAddrCfg = flag.Bool("config-addresses-as-http", false, "Config nsqlookupd http addresses")
-        checkInterval = flag.Int("check-interval", 15, "Time interval for checks/update")
-    )
+	ldPort        = flag.Int("lookupd-tcp-port", 4160, "The nsqlookupd TCP port")
+	dnsAddr       = flag.String("lookupd-dns-address", "", "The nsqlookupd DNS entry")
+	cfgAddr       = flag.String("config-http-address", "", "The config address")
+	httpAddrCfg   = flag.Bool("config-addresses-as-http", false, "Config nsqlookupd http addresses")
+	checkInterval = flag.Int("check-interval", 15, "Time interval for checks/update")
+)
 
 func main() {
 	flag.Parse()


### PR DESCRIPTION
There are some use cases where using 15 seconds is too fast and a longer wait time can be acceptable. This PR adds an option `--check-interval=xx` which allows changing the timer to a longer or shorter duration. 